### PR TITLE
more recent python (3.6.13 instead of 3.6.5.)

### DIFF
--- a/engine-python/Dockerfile-base
+++ b/engine-python/Dockerfile-base
@@ -1,4 +1,4 @@
-FROM python:3.6.5-slim
+FROM python:3.6.13-slim
 
 ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
Migrating to more recent version of python (due to obsolete sqlite3)